### PR TITLE
Add key customization and 180 SRS

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,21 @@ import { createSignal, createEffect, onMount } from 'solid-js';
 import './App.css';
 import TetrisGame from './components/TetrisGame.tsx';
 import PuyoGame from './components/PuyoGame.tsx';
+import PuyoVersusGame from './components/PuyoVersusGame.tsx';
+import PuyoTetrisGame from './components/PuyoTetrisGame.tsx';
 import { RankingEntry } from './components/Ranking.tsx';
 import KeySettingsModal from './components/KeySettingsModal.tsx';
 import { loadKeyBindings, KeyBindings } from './utils/keyBindings';
 
 function App() {
-  const [gameMode, setGameMode] = createSignal<'single' | 'versus' | 'puyo' | null>(null);
+  const [gameMode, setGameMode] = createSignal<
+    | 'single'
+    | 'versus'
+    | 'puyo'
+    | 'puyoVersus'
+    | 'puyoTetris'
+    | null
+  >(null);
   const [animateTitle, setAnimateTitle] = createSignal(true);
   const [rankings, setRankings] = createSignal<RankingEntry[]>([]);
   const [keyBindings, setKeyBindings] = createSignal<KeyBindings>(loadKeyBindings());
@@ -122,6 +131,46 @@ function App() {
                 ぷよぷよ
               </span>
               <div class="absolute inset-0 bg-gradient-to-r from-purple-400 to-pink-400 opacity-0 group-hover:opacity-20 transition-opacity"></div>
+            </button>
+
+            <button
+              class={`relative overflow-hidden group bg-gradient-to-r from-pink-600 to-pink-800
+                hover:from-pink-500 hover:to-pink-600 text-white font-bold py-5 px-6 rounded-lg
+                text-2xl transition-all duration-300 shadow-lg hover:shadow-xl
+                border-2 border-transparent hover:border-pink-300 transform hover:-translate-y-1
+                ${hoveredButton() === 'puyoVersus' ? 'scale-105' : 'scale-100'}`}
+              onClick={() => setGameMode('puyoVersus')}
+              onMouseEnter={() => setHoveredButton('puyoVersus')}
+              onMouseLeave={() => setHoveredButton(null)}
+            >
+              <span class="relative z-10 flex items-center justify-center gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <circle cx="8" cy="12" r="6" stroke-width="2" />
+                  <circle cx="16" cy="12" r="6" stroke-width="2" />
+                </svg>
+                ぷよぷよVS
+              </span>
+              <div class="absolute inset-0 bg-gradient-to-r from-pink-400 to-red-400 opacity-0 group-hover:opacity-20 transition-opacity"></div>
+            </button>
+
+            <button
+              class={`relative overflow-hidden group bg-gradient-to-r from-green-600 to-green-800
+                hover:from-green-500 hover:to-green-600 text-white font-bold py-5 px-6 rounded-lg
+                text-2xl transition-all duration-300 shadow-lg hover:shadow-xl
+                border-2 border-transparent hover:border-green-300 transform hover:-translate-y-1
+                ${hoveredButton() === 'puyoTetris' ? 'scale-105' : 'scale-100'}`}
+              onClick={() => setGameMode('puyoTetris')}
+              onMouseEnter={() => setHoveredButton('puyoTetris')}
+              onMouseLeave={() => setHoveredButton(null)}
+            >
+              <span class="relative z-10 flex items-center justify-center gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <rect x="2" y="9" width="8" height="8" stroke-width="2" />
+                  <circle cx="18" cy="13" r="5" stroke-width="2" />
+                </svg>
+                ぷよ×テト
+              </span>
+              <div class="absolute inset-0 bg-gradient-to-r from-green-400 to-teal-400 opacity-0 group-hover:opacity-20 transition-opacity"></div>
             </button>
 
             <button
@@ -246,13 +295,22 @@ function App() {
                 ? 'シングルプレイ'
                 : gameMode() === 'versus'
                 ? '対戦プレイ'
-                : 'ぷよぷよ'}
+                : gameMode() === 'puyo'
+                ? 'ぷよぷよ'
+                : gameMode() === 'puyoVersus'
+                ? 'ぷよぷよVS'
+                : 'ぷよ×テト'}
             </div>
           </div>
 
-          {gameMode() === 'puyo' ? (
-            <PuyoGame bindings={keyBindings()} />
-          ) : (
+          {gameMode() === 'puyo' && <PuyoGame bindings={keyBindings()} />}
+          {gameMode() === 'puyoVersus' && (
+            <PuyoVersusGame bindings={keyBindings()} />
+          )}
+          {gameMode() === 'puyoTetris' && (
+            <PuyoTetrisGame bindings={keyBindings()} />
+          )}
+          {(gameMode() === 'single' || gameMode() === 'versus') && (
             <TetrisGame mode={gameMode() as 'single' | 'versus'} bindings={keyBindings()} />
           )}
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,17 @@
 import { createSignal, createEffect, onMount } from 'solid-js';
 import './App.css';
 import TetrisGame from './components/TetrisGame.tsx';
+import PuyoGame from './components/PuyoGame.tsx';
 import { RankingEntry } from './components/Ranking.tsx';
+import KeySettingsModal from './components/KeySettingsModal.tsx';
+import { loadKeyBindings, KeyBindings } from './utils/keyBindings';
 
 function App() {
-  const [gameMode, setGameMode] = createSignal<'single' | 'versus' | null>(null);
+  const [gameMode, setGameMode] = createSignal<'single' | 'versus' | 'puyo' | null>(null);
   const [animateTitle, setAnimateTitle] = createSignal(true);
   const [rankings, setRankings] = createSignal<RankingEntry[]>([]);
+  const [keyBindings, setKeyBindings] = createSignal<KeyBindings>(loadKeyBindings());
+  const [showSettings, setShowSettings] = createSignal(false);
   
   // ボタンホバーエフェクト用
   const [hoveredButton, setHoveredButton] = createSignal<string | null>(null);
@@ -80,11 +85,11 @@ function App() {
               </span>
               <div class="absolute inset-0 bg-gradient-to-r from-blue-400 to-cyan-400 opacity-0 group-hover:opacity-20 transition-opacity"></div>
             </button>
-            
-            <button 
-              class={`relative overflow-hidden group bg-gradient-to-r from-red-600 to-red-800 
-                hover:from-red-500 hover:to-red-600 text-white font-bold py-5 px-6 rounded-lg 
-                text-2xl transition-all duration-300 shadow-lg hover:shadow-xl 
+
+          <button
+              class={`relative overflow-hidden group bg-gradient-to-r from-red-600 to-red-800
+                hover:from-red-500 hover:to-red-600 text-white font-bold py-5 px-6 rounded-lg
+                text-2xl transition-all duration-300 shadow-lg hover:shadow-xl
                 border-2 border-transparent hover:border-red-300 transform hover:-translate-y-1
                 ${hoveredButton() === 'versus' ? 'scale-105' : 'scale-100'}`}
               onClick={() => setGameMode('versus')}
@@ -99,6 +104,30 @@ function App() {
               </span>
               <div class="absolute inset-0 bg-gradient-to-r from-red-400 to-orange-400 opacity-0 group-hover:opacity-20 transition-opacity"></div>
             </button>
+
+            <button
+              class={`relative overflow-hidden group bg-gradient-to-r from-purple-600 to-purple-800
+                hover:from-purple-500 hover:to-purple-600 text-white font-bold py-5 px-6 rounded-lg
+                text-2xl transition-all duration-300 shadow-lg hover:shadow-xl
+                border-2 border-transparent hover:border-purple-300 transform hover:-translate-y-1
+                ${hoveredButton() === 'puyo' ? 'scale-105' : 'scale-100'}`}
+              onClick={() => setGameMode('puyo')}
+              onMouseEnter={() => setHoveredButton('puyo')}
+              onMouseLeave={() => setHoveredButton(null)}
+            >
+              <span class="relative z-10 flex items-center justify-center gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <circle cx="12" cy="12" r="10" stroke-width="2" />
+                </svg>
+                ぷよぷよ
+              </span>
+              <div class="absolute inset-0 bg-gradient-to-r from-purple-400 to-pink-400 opacity-0 group-hover:opacity-20 transition-opacity"></div>
+            </button>
+
+            <button
+              class="bg-gray-700 hover:bg-gray-600 text-white py-3 px-6 rounded-lg transition-colors shadow-md"
+              onClick={() => setShowSettings(true)}
+            >キー設定</button>
             
             {/* 操作方法 */}
             <div class="mt-2 text-gray-400 text-sm bg-gray-800 bg-opacity-50 px-4 py-3 rounded-md border border-gray-700 shadow-md">
@@ -213,12 +242,27 @@ function App() {
               メニューに戻る
             </button>
             <div class="text-2xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 to-blue-500 px-4 py-1 rounded-md border border-gray-700 bg-opacity-20 bg-gray-800">
-              {gameMode() === 'single' ? 'シングルプレイ' : '対戦プレイ'}
+              {gameMode() === 'single'
+                ? 'シングルプレイ'
+                : gameMode() === 'versus'
+                ? '対戦プレイ'
+                : 'ぷよぷよ'}
             </div>
           </div>
-          
-          <TetrisGame mode={gameMode()!} />
+
+          {gameMode() === 'puyo' ? (
+            <PuyoGame bindings={keyBindings()} />
+          ) : (
+            <TetrisGame mode={gameMode() as 'single' | 'versus'} bindings={keyBindings()} />
+          )}
         </div>
+      )}
+      {showSettings() && (
+        <KeySettingsModal
+          bindings={keyBindings()}
+          setBindings={setKeyBindings}
+          onClose={() => setShowSettings(false)}
+        />
       )}
     </div>
   );

--- a/src/components/KeySettingsModal.tsx
+++ b/src/components/KeySettingsModal.tsx
@@ -1,0 +1,69 @@
+import { createSignal, onMount, onCleanup } from 'solid-js';
+import { KeyBindings, defaultKeyBindings, saveKeyBindings } from '../utils/keyBindings';
+
+interface Props { onClose: () => void; bindings: KeyBindings; setBindings: (b: KeyBindings) => void; }
+
+const actionLabels: Record<keyof KeyBindings, string> = {
+  moveLeft: '左移動',
+  moveRight: '右移動',
+  rotate: '回転',
+  rotate180: '180回転',
+  softDrop: 'ソフトドロップ',
+  hardDrop: 'ハードドロップ',
+  hold: 'ホールド',
+  pause: 'ポーズ',
+  reset: 'リセット',
+};
+
+const KeySettingsModal = (props: Props) => {
+  const [editing, setEditing] = createSignal<keyof KeyBindings | null>(null);
+  const [localBindings, setLocalBindings] = createSignal<KeyBindings>({ ...props.bindings });
+
+  const handleKey = (e: KeyboardEvent) => {
+    const key = editing();
+    if (!key) return;
+    e.preventDefault();
+    const value = e.key;
+    setLocalBindings({ ...localBindings(), [key]: value });
+    setEditing(null);
+  };
+
+  onMount(() => window.addEventListener('keydown', handleKey));
+  onCleanup(() => window.removeEventListener('keydown', handleKey));
+
+  const save = () => {
+    const b = localBindings();
+    props.setBindings(b);
+    saveKeyBindings(b);
+    props.onClose();
+  };
+
+  const reset = () => setLocalBindings({ ...defaultKeyBindings });
+
+  const displayKey = (k: string) => (k === ' ' ? 'Space' : k);
+
+  return (
+    <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div class="bg-gray-800 p-6 rounded-lg shadow-lg w-80">
+        <h2 class="text-xl mb-4">キー設定</h2>
+        <div class="space-y-2">
+          {(Object.keys(actionLabels) as (keyof KeyBindings)[]).map((action) => (
+            <div class="flex justify-between items-center" >
+              <span>{actionLabels[action]}</span>
+              <button class="bg-gray-700 px-2 py-1 rounded" onClick={() => setEditing(action)}>
+                {editing() === action ? '...': displayKey(localBindings()[action])}
+              </button>
+            </div>
+          ))}
+        </div>
+        <div class="flex justify-end gap-2 mt-4">
+          <button class="bg-gray-700 px-3 py-1 rounded" onClick={reset}>デフォルト</button>
+          <button class="bg-blue-700 px-3 py-1 rounded" onClick={save}>保存</button>
+          <button class="bg-gray-700 px-3 py-1 rounded" onClick={props.onClose}>閉じる</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default KeySettingsModal;

--- a/src/components/PuyoBoard.tsx
+++ b/src/components/PuyoBoard.tsx
@@ -15,7 +15,7 @@ const colors = [
 ];
 
 const PuyoBoard: Component<Props> = (props) => {
-  const size = props.cellSize ?? 48;
+  const size = props.cellSize ?? 64;
   const getCell = (r:number,c:number) => {
     if(props.pair){
       const { row,col,orientation,colors:cl } = props.pair;

--- a/src/components/PuyoBoard.tsx
+++ b/src/components/PuyoBoard.tsx
@@ -1,0 +1,52 @@
+import { Component } from 'solid-js';
+import { PuyoPair } from '../hooks/usePuyo';
+
+interface Props {
+  board: (number|null)[][];
+  pair: PuyoPair | null;
+}
+
+const colors = [
+  'bg-red-500',
+  'bg-blue-500',
+  'bg-green-500',
+  'bg-yellow-400'
+];
+
+const PuyoBoard: Component<Props> = (props) => {
+  const getCell = (r:number,c:number) => {
+    if(props.pair){
+      const { row,col,orientation,colors:cl } = props.pair;
+      const cells = pairCells(row,col,orientation);
+      for(let i=0;i<2;i++){
+        const [y,x] = cells[i];
+        if(y===r && x===c) return cl[i];
+      }
+    }
+    return props.board[r][c];
+  };
+
+  const pairCells = (r:number,c:number,o:number):[number,number][] => {
+    const c1:[number,number] = [r,c];
+    const c2:[number,number] = [r,c];
+    if(o===0) c2[0]=r-1;
+    if(o===1) c2[1]=c+1;
+    if(o===2) c2[0]=r+1;
+    if(o===3) c2[1]=c-1;
+    return [c1,c2];
+  };
+
+  return (
+    <div class="bg-gray-800 p-2 rounded border border-gray-600">
+      <div class="grid grid-cols-6 gap-[1px] bg-gray-700">
+        {props.board.map((row,rowIndex)=>
+          row.map((_,colIndex)=>{
+            const cv = getCell(rowIndex,colIndex);
+            return <div class={`w-6 h-6 sm:w-8 sm:h-8 ${cv!==null?colors[cv]:'bg-gray-900'} rounded-sm`}/>;
+          })
+        )}
+      </div>
+    </div>
+  );
+};
+export default PuyoBoard;

--- a/src/components/PuyoBoard.tsx
+++ b/src/components/PuyoBoard.tsx
@@ -15,7 +15,7 @@ const colors = [
 ];
 
 const PuyoBoard: Component<Props> = (props) => {
-  const size = props.cellSize ?? 32;
+  const size = props.cellSize ?? 48;
   const getCell = (r:number,c:number) => {
     if(props.pair){
       const { row,col,orientation,colors:cl } = props.pair;
@@ -39,15 +39,15 @@ const PuyoBoard: Component<Props> = (props) => {
   };
 
   return (
-    <div class="bg-gray-800 p-2 rounded border border-gray-600 inline-block">
-      <div class="grid grid-cols-6 gap-[1px] bg-gray-700">
+    <div class="bg-gray-800 p-2 rounded-lg border border-gray-600 inline-block">
+      <div class="grid grid-cols-6 gap-1 bg-gray-700 p-1 rounded">
         {props.board.map((row, rowIndex) =>
           row.map((_, colIndex) => {
             const cv = getCell(rowIndex, colIndex);
             return (
               <div
                 style={{ width: `${size}px`, height: `${size}px` }}
-                class={`${cv !== null ? colors[cv] : 'bg-gray-900'} rounded-sm`}
+                class={`${cv !== null ? colors[cv] : 'bg-gray-900'} rounded-full border border-gray-900`}
               />
             );
           })

--- a/src/components/PuyoBoard.tsx
+++ b/src/components/PuyoBoard.tsx
@@ -2,8 +2,9 @@ import { Component } from 'solid-js';
 import { PuyoPair } from '../hooks/usePuyo';
 
 interface Props {
-  board: (number|null)[][];
+  board: (number | null)[][];
   pair: PuyoPair | null;
+  cellSize?: number;
 }
 
 const colors = [
@@ -14,6 +15,7 @@ const colors = [
 ];
 
 const PuyoBoard: Component<Props> = (props) => {
+  const size = props.cellSize ?? 32;
   const getCell = (r:number,c:number) => {
     if(props.pair){
       const { row,col,orientation,colors:cl } = props.pair;
@@ -37,12 +39,17 @@ const PuyoBoard: Component<Props> = (props) => {
   };
 
   return (
-    <div class="bg-gray-800 p-2 rounded border border-gray-600">
+    <div class="bg-gray-800 p-2 rounded border border-gray-600 inline-block">
       <div class="grid grid-cols-6 gap-[1px] bg-gray-700">
-        {props.board.map((row,rowIndex)=>
-          row.map((_,colIndex)=>{
-            const cv = getCell(rowIndex,colIndex);
-            return <div class={`w-6 h-6 sm:w-8 sm:h-8 ${cv!==null?colors[cv]:'bg-gray-900'} rounded-sm`}/>;
+        {props.board.map((row, rowIndex) =>
+          row.map((_, colIndex) => {
+            const cv = getCell(rowIndex, colIndex);
+            return (
+              <div
+                style={{ width: `${size}px`, height: `${size}px` }}
+                class={`${cv !== null ? colors[cv] : 'bg-gray-900'} rounded-sm`}
+              />
+            );
           })
         )}
       </div>

--- a/src/components/PuyoBoard.tsx
+++ b/src/components/PuyoBoard.tsx
@@ -11,7 +11,9 @@ const colors = [
   'bg-red-500',
   'bg-blue-500',
   'bg-green-500',
-  'bg-yellow-400'
+  'bg-yellow-400',
+  // index 4: ojama
+  'bg-gray-400'
 ];
 
 const PuyoBoard: Component<Props> = (props) => {

--- a/src/components/PuyoGame.tsx
+++ b/src/components/PuyoGame.tsx
@@ -22,7 +22,7 @@ const PuyoGame = (props: Props) => {
 
   return (
     <div class="flex flex-col items-center gap-4">
-      <PuyoBoard board={game.board()} pair={game.current()} cellSize={props.cellSize ?? 48} />
+      <PuyoBoard board={game.board()} pair={game.current()} cellSize={props.cellSize ?? 64} />
       {game.isGameOver() && (
         <div class="text-red-500 font-bold">ゲームオーバー</div>
       )}

--- a/src/components/PuyoGame.tsx
+++ b/src/components/PuyoGame.tsx
@@ -1,0 +1,33 @@
+import { onMount, onCleanup } from 'solid-js';
+import PuyoBoard from './PuyoBoard.tsx';
+import { usePuyo } from '../hooks/usePuyo';
+import { KeyBindings } from '../utils/keyBindings';
+
+interface Props { bindings: KeyBindings }
+
+const PuyoGame = (props:Props) => {
+  const game = usePuyo();
+
+  onMount(() => {
+    const downHandler = (e: KeyboardEvent) => {
+      if (game.isGameOver()) return;
+      if(e.key === props.bindings.moveLeft) game.moveLeft();
+      if(e.key === props.bindings.moveRight) game.moveRight();
+      if(e.key === props.bindings.rotate) game.rotate();
+      if(e.key === props.bindings.softDrop) game.softDrop();
+    };
+    window.addEventListener('keydown', downHandler);
+    onCleanup(() => window.removeEventListener('keydown', downHandler));
+  });
+
+  return (
+    <div class="flex flex-col items-center gap-4">
+      <PuyoBoard board={game.board()} pair={game.current()} />
+      {game.isGameOver() && (
+        <div class="text-red-500 font-bold">ゲームオーバー</div>
+      )}
+    </div>
+  );
+};
+
+export default PuyoGame;

--- a/src/components/PuyoGame.tsx
+++ b/src/components/PuyoGame.tsx
@@ -22,7 +22,7 @@ const PuyoGame = (props: Props) => {
 
   return (
     <div class="flex flex-col items-center gap-4">
-      <PuyoBoard board={game.board()} pair={game.current()} cellSize={props.cellSize ?? 32} />
+      <PuyoBoard board={game.board()} pair={game.current()} cellSize={props.cellSize ?? 48} />
       {game.isGameOver() && (
         <div class="text-red-500 font-bold">ゲームオーバー</div>
       )}

--- a/src/components/PuyoGame.tsx
+++ b/src/components/PuyoGame.tsx
@@ -3,9 +3,9 @@ import PuyoBoard from './PuyoBoard.tsx';
 import { usePuyo } from '../hooks/usePuyo';
 import { KeyBindings } from '../utils/keyBindings';
 
-interface Props { bindings: KeyBindings }
+interface Props { bindings: KeyBindings; cellSize?: number }
 
-const PuyoGame = (props:Props) => {
+const PuyoGame = (props: Props) => {
   const game = usePuyo();
 
   onMount(() => {
@@ -22,7 +22,7 @@ const PuyoGame = (props:Props) => {
 
   return (
     <div class="flex flex-col items-center gap-4">
-      <PuyoBoard board={game.board()} pair={game.current()} />
+      <PuyoBoard board={game.board()} pair={game.current()} cellSize={props.cellSize ?? 32} />
       {game.isGameOver() && (
         <div class="text-red-500 font-bold">ゲームオーバー</div>
       )}

--- a/src/components/PuyoTetrisGame.tsx
+++ b/src/components/PuyoTetrisGame.tsx
@@ -1,0 +1,26 @@
+import PuyoGame from './PuyoGame.tsx';
+import TetrisGame from './TetrisGame.tsx';
+import { KeyBindings } from '../utils/keyBindings';
+
+interface Props { bindings: KeyBindings }
+
+const arrowBindings: KeyBindings = {
+  moveLeft: 'ArrowLeft',
+  moveRight: 'ArrowRight',
+  rotate: 'ArrowUp',
+  rotate180: 'Insert',
+  softDrop: 'ArrowDown',
+  hardDrop: 'Enter',
+  hold: 'Shift',
+  pause: 'p',
+  reset: 'r',
+};
+
+const PuyoTetrisGame = (props: Props) => (
+  <div class="flex gap-4">
+    <PuyoGame bindings={props.bindings} />
+    <TetrisGame mode="single" bindings={arrowBindings} />
+  </div>
+);
+
+export default PuyoTetrisGame;

--- a/src/components/PuyoTetrisGame.tsx
+++ b/src/components/PuyoTetrisGame.tsx
@@ -18,7 +18,7 @@ const arrowBindings: KeyBindings = {
 
 const PuyoTetrisGame = (props: Props) => (
   <div class="flex gap-4 justify-center">
-    <PuyoGame bindings={props.bindings} cellSize={24} />
+    <PuyoGame bindings={props.bindings} cellSize={32} />
     <TetrisGame mode="single" bindings={arrowBindings} />
   </div>
 );

--- a/src/components/PuyoTetrisGame.tsx
+++ b/src/components/PuyoTetrisGame.tsx
@@ -17,7 +17,7 @@ const arrowBindings: KeyBindings = {
 };
 
 const PuyoTetrisGame = (props: Props) => (
-  <div class="flex gap-4">
+  <div class="flex gap-4 justify-center">
     <PuyoGame bindings={props.bindings} cellSize={24} />
     <TetrisGame mode="single" bindings={arrowBindings} />
   </div>

--- a/src/components/PuyoTetrisGame.tsx
+++ b/src/components/PuyoTetrisGame.tsx
@@ -18,7 +18,7 @@ const arrowBindings: KeyBindings = {
 
 const PuyoTetrisGame = (props: Props) => (
   <div class="flex gap-4">
-    <PuyoGame bindings={props.bindings} />
+    <PuyoGame bindings={props.bindings} cellSize={24} />
     <TetrisGame mode="single" bindings={arrowBindings} />
   </div>
 );

--- a/src/components/PuyoVersusGame.tsx
+++ b/src/components/PuyoVersusGame.tsx
@@ -31,11 +31,12 @@ const PuyoVersusGame = (props: Props) => {
   return (
     <div class="flex gap-4">
       <div class="flex flex-col items-center gap-2">
-        <PuyoBoard board={player1.board()} pair={player1.current()} cellSize={24} />
+        {/* enlarge board for better visibility in versus mode */}
+        <PuyoBoard board={player1.board()} pair={player1.current()} cellSize={32} />
         {player1.isGameOver() && <div class="text-red-500">ゲームオーバー</div>}
       </div>
       <div class="flex flex-col items-center gap-2">
-        <PuyoBoard board={player2.board()} pair={player2.current()} cellSize={24} />
+        <PuyoBoard board={player2.board()} pair={player2.current()} cellSize={32} />
         {player2.isGameOver() && <div class="text-red-500">ゲームオーバー</div>}
       </div>
     </div>

--- a/src/components/PuyoVersusGame.tsx
+++ b/src/components/PuyoVersusGame.tsx
@@ -1,0 +1,45 @@
+import { onMount, onCleanup } from 'solid-js';
+import PuyoBoard from './PuyoBoard.tsx';
+import { usePuyo } from '../hooks/usePuyo';
+import { KeyBindings } from '../utils/keyBindings';
+
+interface Props { bindings: KeyBindings }
+
+const PuyoVersusGame = (props: Props) => {
+  const player1 = usePuyo();
+  const player2 = usePuyo();
+
+  onMount(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (!player1.isGameOver()) {
+        if (e.key === props.bindings.moveLeft) player1.moveLeft();
+        if (e.key === props.bindings.moveRight) player1.moveRight();
+        if (e.key === props.bindings.rotate) player1.rotate();
+        if (e.key === props.bindings.softDrop) player1.softDrop();
+      }
+      if (!player2.isGameOver()) {
+        if (e.key === 'ArrowLeft') player2.moveLeft();
+        if (e.key === 'ArrowRight') player2.moveRight();
+        if (e.key === 'ArrowUp') player2.rotate();
+        if (e.key === 'ArrowDown') player2.softDrop();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    onCleanup(() => window.removeEventListener('keydown', handler));
+  });
+
+  return (
+    <div class="flex gap-4">
+      <div class="flex flex-col items-center gap-2">
+        <PuyoBoard board={player1.board()} pair={player1.current()} />
+        {player1.isGameOver() && <div class="text-red-500">ゲームオーバー</div>}
+      </div>
+      <div class="flex flex-col items-center gap-2">
+        <PuyoBoard board={player2.board()} pair={player2.current()} />
+        {player2.isGameOver() && <div class="text-red-500">ゲームオーバー</div>}
+      </div>
+    </div>
+  );
+};
+
+export default PuyoVersusGame;

--- a/src/components/PuyoVersusGame.tsx
+++ b/src/components/PuyoVersusGame.tsx
@@ -6,8 +6,8 @@ import { KeyBindings } from '../utils/keyBindings';
 interface Props { bindings: KeyBindings }
 
 const PuyoVersusGame = (props: Props) => {
-  const player1 = usePuyo();
-  const player2 = usePuyo();
+  const player1 = usePuyo((c)=>player2.addOjama(Math.floor(c/4)));
+  const player2 = usePuyo((c)=>player1.addOjama(Math.floor(c/4)));
 
   onMount(() => {
     const handler = (e: KeyboardEvent) => {

--- a/src/components/PuyoVersusGame.tsx
+++ b/src/components/PuyoVersusGame.tsx
@@ -29,7 +29,7 @@ const PuyoVersusGame = (props: Props) => {
   });
 
   return (
-    <div class="flex gap-4">
+    <div class="flex gap-4 justify-center">
       <div class="flex flex-col items-center gap-2">
         {/* enlarge board for better visibility in versus mode */}
         <PuyoBoard board={player1.board()} pair={player1.current()} cellSize={32} />

--- a/src/components/PuyoVersusGame.tsx
+++ b/src/components/PuyoVersusGame.tsx
@@ -31,11 +31,11 @@ const PuyoVersusGame = (props: Props) => {
   return (
     <div class="flex gap-4">
       <div class="flex flex-col items-center gap-2">
-        <PuyoBoard board={player1.board()} pair={player1.current()} />
+        <PuyoBoard board={player1.board()} pair={player1.current()} cellSize={24} />
         {player1.isGameOver() && <div class="text-red-500">ゲームオーバー</div>}
       </div>
       <div class="flex flex-col items-center gap-2">
-        <PuyoBoard board={player2.board()} pair={player2.current()} />
+        <PuyoBoard board={player2.board()} pair={player2.current()} cellSize={24} />
         {player2.isGameOver() && <div class="text-red-500">ゲームオーバー</div>}
       </div>
     </div>

--- a/src/components/PuyoVersusGame.tsx
+++ b/src/components/PuyoVersusGame.tsx
@@ -32,11 +32,11 @@ const PuyoVersusGame = (props: Props) => {
     <div class="flex gap-4 justify-center">
       <div class="flex flex-col items-center gap-2">
         {/* enlarge board for better visibility in versus mode */}
-        <PuyoBoard board={player1.board()} pair={player1.current()} cellSize={32} />
+        <PuyoBoard board={player1.board()} pair={player1.current()} cellSize={48} />
         {player1.isGameOver() && <div class="text-red-500">ゲームオーバー</div>}
       </div>
       <div class="flex flex-col items-center gap-2">
-        <PuyoBoard board={player2.board()} pair={player2.current()} cellSize={32} />
+        <PuyoBoard board={player2.board()} pair={player2.current()} cellSize={48} />
         {player2.isGameOver() && <div class="text-red-500">ゲームオーバー</div>}
       </div>
     </div>

--- a/src/components/TetrisGame.tsx
+++ b/src/components/TetrisGame.tsx
@@ -6,8 +6,11 @@ import GameOverModal from './GameOverModal.tsx';
 import ResultModal from './ResultModal.tsx';
 import { useTetris } from '../hooks/useTetris';
 
+import { KeyBindings } from '../utils/keyBindings';
+
 interface TetrisGameProps {
   mode: 'single' | 'versus';
+  bindings: KeyBindings;
 }
 
 const TetrisGame = (props: TetrisGameProps) => {
@@ -87,7 +90,7 @@ const TetrisGame = (props: TetrisGameProps) => {
     // キー状態管理
     const handleKeyDown = (e: KeyboardEvent) => {
       // 左移動 DAS/ARR
-      if ((e.key === 'a' || e.key === 'A') && !leftHeld()) {
+      if (e.key === props.bindings.moveLeft && !leftHeld()) {
         setLeftHeld(true);
         player1.moveLeft();
         leftDas = window.setTimeout(() => {
@@ -95,7 +98,7 @@ const TetrisGame = (props: TetrisGameProps) => {
         }, 300);
       }
       // 右移動 DAS/ARR
-      if ((e.key === 'd' || e.key === 'D') && !rightHeld()) {
+      if (e.key === props.bindings.moveRight && !rightHeld()) {
         setRightHeld(true);
         player1.moveRight();
         rightDas = window.setTimeout(() => {
@@ -103,17 +106,20 @@ const TetrisGame = (props: TetrisGameProps) => {
         }, 300);
       }
       // ソフトドロップ開始
-      if (e.key === 's' || e.key === 'S') {
+      if (e.key === props.bindings.softDrop) {
         player1.setSoftDropping(true);
       }
       // 回転・ホールド・ハードドロップ
-      if (e.key === 'w' || e.key === 'W') player1.rotate();
+      if (e.key === props.bindings.rotate) player1.rotate();
+      if (e.key === props.bindings.rotate180) player1.rotate180();
       // クリアアニメーション中はハードドロップを無効化
-      if (e.key === ' ' && !spaceHeld() && player1.clearingRows().length === 0) {
+      if (e.key === props.bindings.hardDrop && !spaceHeld() && player1.clearingRows().length === 0) {
         player1.hardDrop();
         setSpaceHeld(true);
       }
-      if (e.key === 'c' || e.key === 'C') player1.holdPiece();
+      if (e.key === props.bindings.hold) player1.holdPiece();
+      if (e.key === props.bindings.pause) player1.pauseGame();
+      if (e.key === props.bindings.reset) restartGame();
 
       // 対戦モードの場合、プレイヤー2のキー操作（矢印キー）
       if (props.mode === 'versus' && player2) {
@@ -128,20 +134,20 @@ const TetrisGame = (props: TetrisGameProps) => {
     };
 
     const handleKeyUp = (e: KeyboardEvent) => {
-      if (e.key === 'a' || e.key === 'A') {
+      if (e.key === props.bindings.moveLeft) {
         setLeftHeld(false);
         clearTimeout(leftDas);
         clearInterval(leftArr);
       }
-      if (e.key === 'd' || e.key === 'D') {
+      if (e.key === props.bindings.moveRight) {
         setRightHeld(false);
         clearTimeout(rightDas);
         clearInterval(rightArr);
       }
-      if (e.key === 's' || e.key === 'S') {
+      if (e.key === props.bindings.softDrop) {
         player1.setSoftDropping(false);
       }
-      if (e.key === ' ') {
+      if (e.key === props.bindings.hardDrop) {
         setSpaceHeld(false);
       }
     };

--- a/src/hooks/usePuyo.ts
+++ b/src/hooks/usePuyo.ts
@@ -1,0 +1,152 @@
+import { createSignal, createEffect, onCleanup } from 'solid-js';
+
+export interface PuyoPair {
+  row: number; // position of first puyo
+  col: number;
+  orientation: number; // 0:up 1:right 2:down 3:left
+  colors: [number, number];
+}
+
+export const usePuyo = () => {
+  const WIDTH = 6;
+  const HEIGHT = 12;
+  const DROP_INTERVAL = 700;
+
+  const [board, setBoard] = createSignal<(number|null)[][]>(
+    Array(HEIGHT).fill(0).map(() => Array(WIDTH).fill(null))
+  );
+  const [current, setCurrent] = createSignal<PuyoPair | null>(null);
+  const [gameOver, setGameOver] = createSignal(false);
+
+  const newPiece = () => {
+    const pair: PuyoPair = {
+      row: -1,
+      col: Math.floor(WIDTH/2) -1,
+      orientation: 0,
+      colors: [Math.floor(Math.random()*4), Math.floor(Math.random()*4)]
+    };
+    if (!isValidPosition(pair.row, pair.col, pair.orientation)) {
+      setGameOver(true);
+    }
+    setCurrent(pair);
+  };
+
+  const isValidPosition = (r:number, c:number, o:number) => {
+    const cells = pairCells(r,c,o);
+    return cells.every(([y,x]) =>
+      y < HEIGHT && x >=0 && x < WIDTH && (y < 0 || board()[y][x] === null)
+    );
+  };
+
+  const pairCells = (r:number,c:number,o:number): [number,number][] => {
+    const [c1,c2] = [ [r,c], [r,c] ];
+    if (o === 0) c2[0] = r-1;
+    if (o === 1) c2[1] = c+1;
+    if (o === 2) c2[0] = r+1;
+    if (o === 3) c2[1] = c-1;
+    return [c1 as [number,number], c2 as [number,number]];
+  };
+
+  const move = (dr:number, dc:number) => {
+    const p = current();
+    if (!p) return;
+    const nr = p.row + dr;
+    const nc = p.col + dc;
+    if (isValidPosition(nr,nc,p.orientation)) setCurrent({ ...p, row:nr, col:nc });
+  };
+
+  const rotate = () => {
+    const p = current();
+    if (!p) return;
+    const no = (p.orientation + 1)%4;
+    if (isValidPosition(p.row,p.col,no)) setCurrent({ ...p, orientation:no });
+  };
+
+  const tick = () => {
+    const p = current();
+    if (!p) return;
+    if (isValidPosition(p.row+1, p.col, p.orientation)) {
+      setCurrent({ ...p, row: p.row+1 });
+    } else {
+      fixPiece();
+    }
+  };
+
+  const fixPiece = () => {
+    const p = current();
+    if (!p) return;
+    const cells = pairCells(p.row, p.col, p.orientation);
+    const newBoard = board().map(row => [...row]);
+    cells.forEach(([y,x], idx) => {
+      if (y >= 0 && y < HEIGHT) newBoard[y][x] = p.colors[idx];
+    });
+    setBoard(newBoard);
+    clearGroups();
+    newPiece();
+  };
+
+  const clearGroups = () => {
+    const b = board().map(r=>[...r]);
+    const visited = Array(HEIGHT).fill(0).map(()=>Array(WIDTH).fill(false));
+    let cleared = false;
+    for(let y=0;y<HEIGHT;y++){
+      for(let x=0;x<WIDTH;x++){
+        const color = b[y][x];
+        if(color===null || visited[y][x]) continue;
+        const q:[[number,number]] = [[y,x]];
+        const group:[[number,number]] = [] as any;
+        visited[y][x]=true;
+        while(q.length){
+          const [cy,cx] = q.pop()!;
+          group.push([cy,cx]);
+          [[1,0],[-1,0],[0,1],[0,-1]].forEach(([dy,dx])=>{
+            const ny=cy+dy,nx=cx+dx;
+            if(ny>=0&&ny<HEIGHT&&nx>=0&&nx<WIDTH&&!visited[ny][nx]&&b[ny][nx]===color){
+              visited[ny][nx]=true;
+              q.push([ny,nx]);
+            }
+          });
+        }
+        if(group.length>=4){
+          cleared=true;
+          group.forEach(([gy,gx])=>{ b[gy][gx]=null; });
+        }
+      }
+    }
+    if(cleared){
+      // apply gravity
+      for(let x=0;x<WIDTH;x++){
+        let stack:number[] = [];
+        for(let y=HEIGHT-1;y>=0;y--){
+          if(b[y][x]!==null) stack.push(b[y][x]!);
+        }
+        for(let y=HEIGHT-1;y>=0;y--){
+          b[y][x]=stack[HEIGHT-1-y] ?? null;
+        }
+      }
+      setBoard(b);
+      clearGroups();
+    } else {
+      setBoard(b);
+    }
+  };
+
+  // game loop
+  createEffect(() => {
+    if(gameOver()) return;
+    const id = setInterval(tick, DROP_INTERVAL);
+    onCleanup(() => clearInterval(id));
+  });
+
+  newPiece();
+
+  return {
+    board,
+    current,
+    moveLeft: () => move(0,-1),
+    moveRight: () => move(0,1),
+    softDrop: () => move(1,0),
+    rotate,
+    isGameOver: gameOver
+  };
+};

--- a/src/hooks/usePuyo.ts
+++ b/src/hooks/usePuyo.ts
@@ -81,7 +81,7 @@ export const usePuyo = (onClear?: (count:number)=>void) => {
     const p = current();
     if (!p) return;
     const cells = pairCells(p.row, p.col, p.orientation);
-    const newBoard = board().map((row) => [...row]);
+    const newBoard = board().map((row: (number | null)[]) => [...row]);
     cells.forEach(([y, x], idx) => {
       if (y >= 0 && y < HEIGHT) newBoard[y][x] = p.colors[idx];
     });
@@ -107,15 +107,15 @@ export const usePuyo = (onClear?: (count:number)=>void) => {
     }
   };
 
-  const addOjama = (lines:number) => {
-    if(lines<=0) return;
-    setBoard(prev => {
-      const b = prev.map(r => [...r]);
-      for(let i=0;i<lines;i++){
+  const addOjama = (lines: number) => {
+    if (lines <= 0) return;
+    setBoard((prev: (number | null)[][]) => {
+      const b = prev.map(row => [...row]);
+      for (let i = 0; i < lines; i++) {
         const removed = b.shift();
-        if(removed && removed.some(v=>v!==null)) setGameOver(true);
-        const hole = Math.floor(Math.random()*WIDTH);
-        const row = Array(WIDTH).fill(4);
+        if (removed && removed.some(v => v !== null)) setGameOver(true);
+        const hole = Math.floor(Math.random() * WIDTH);
+        const row = Array(WIDTH).fill(4) as (number | null)[];
         row[hole] = null;
         b.push(row);
       }
@@ -124,7 +124,7 @@ export const usePuyo = (onClear?: (count:number)=>void) => {
   };
 
   const clearGroups = () => {
-    const b = board().map((r) => [...r]);
+    const b = board().map((r: (number | null)[]) => [...r]);
     const visited = Array(HEIGHT).fill(0).map(()=>Array(WIDTH).fill(false));
     let cleared = false;
     let clearedCount = 0;
@@ -132,8 +132,8 @@ export const usePuyo = (onClear?: (count:number)=>void) => {
       for(let x=0;x<WIDTH;x++){
         const color = b[y][x];
         if(color===null || color===4 || visited[y][x]) continue;
-        const q:[[number,number]] = [[y,x]];
-        const group:[[number,number]] = [] as any;
+        const q: [number, number][] = [[y, x]];
+        const group: [number, number][] = [];
         visited[y][x]=true;
         while(q.length){
           const [cy,cx] = q.pop()!;

--- a/src/hooks/useTetris.ts
+++ b/src/hooks/useTetris.ts
@@ -77,13 +77,14 @@ export const useTetris = (seed?: number, onAttackInitial?: (lines: number) => vo
     const pos = currentPosition();
     if (cp && pos) {
       let newRow = pos.row - lines;
-      // 有効位置になるまで更に上へ移動
+      const limit = -cp.shape.length; // 最大で全て隠れる位置まで
+      // 有効位置になるまで上へ移動
       while (!isValidPosition({ row: newRow, col: pos.col }, cp.shape)) {
         newRow--;
         // それでも置けない場合はゲームオーバー
-        if (newRow < -4) {
+        if (newRow < limit) {
           setGameOver(true);
-          break;
+          return;
         }
       }
       setCurrentPosition({ row: newRow, col: pos.col });

--- a/src/hooks/useTetris.ts
+++ b/src/hooks/useTetris.ts
@@ -62,15 +62,31 @@ export const useTetris = (seed?: number, onAttackInitial?: (lines: number) => vo
     if (lines <= 0) return;
     const current = board().slice();
     const filtered = current.slice(lines);
-    const garbageRows = Array(lines).fill(null).map(() => {
-      const hole = Math.floor(Math.random() * BOARD_WIDTH);
-      return Array(BOARD_WIDTH).fill(8).map((_, i) => i === hole ? null : 8);
-    });
+    const garbageRows = Array(lines)
+      .fill(null)
+      .map(() => {
+        const hole = Math.floor(Math.random() * BOARD_WIDTH);
+        return Array(BOARD_WIDTH)
+          .fill(8)
+          .map((_, i) => (i === hole ? null : 8));
+      });
     setBoard([...filtered, ...garbageRows]);
-    // 追加：ボード上部切り詰め分だけミノ位置を上に移動
+
+    // 上に押し出された分だけミノを移動させる
+    const cp = currentPiece();
     const pos = currentPosition();
-    if (pos) {
-      setCurrentPosition({ row: pos.row - lines, col: pos.col });
+    if (cp && pos) {
+      let newRow = pos.row - lines;
+      // 有効位置になるまで更に上へ移動
+      while (!isValidPosition({ row: newRow, col: pos.col }, cp.shape)) {
+        newRow--;
+        // それでも置けない場合はゲームオーバー
+        if (newRow < -4) {
+          setGameOver(true);
+          break;
+        }
+      }
+      setCurrentPosition({ row: newRow, col: pos.col });
       updateGhostPosition();
     }
   };

--- a/src/hooks/useTetris.ts
+++ b/src/hooks/useTetris.ts
@@ -1,5 +1,5 @@
 import { createSignal, createEffect, onCleanup } from 'solid-js';
-import { Tetromino, rotateTetrominoSRS, createTetrominoGenerator } from '../models/tetromino';
+import { Tetromino, rotateTetrominoSRS, rotateTetrominoSRS180, createTetrominoGenerator } from '../models/tetromino';
 
 export interface Position {
   row: number;
@@ -320,6 +320,24 @@ export const useTetris = (seed?: number, onAttackInitial?: (lines: number) => vo
     }
   };
 
+  const rotate180 = () => {
+    const cp = currentPiece();
+    const pos = currentPosition();
+    if (!cp || !pos || gameOver() || isPaused()) return;
+
+    const attempts = rotateTetrominoSRS180(cp);
+    for (const { piece: newPiece, offset } of attempts) {
+      const np = { row: pos.row + offset.row, col: pos.col + offset.col };
+      if (isValidPosition(np, newPiece.shape)) {
+        setCurrentPiece(newPiece);
+        setCurrentPosition(np);
+        updateGhostPosition();
+        return;
+      }
+    }
+    updateGhostPosition();
+  };
+
   // ハードドロップ（一番下まで一気に落とす）
   const hardDrop = () => {
     // 連打防止
@@ -519,6 +537,7 @@ export const useTetris = (seed?: number, onAttackInitial?: (lines: number) => vo
     moveRight,
     moveDown,
     rotate,
+    rotate180,
     hardDrop,
     holdPiece,
     pauseGame: () => setIsPaused(!isPaused()),

--- a/src/hooks/useTetris.ts
+++ b/src/hooks/useTetris.ts
@@ -87,6 +87,15 @@ export const useTetris = (seed?: number, onAttackInitial?: (lines: number) => vo
         }
       }
       setCurrentPosition({ row: newRow, col: pos.col });
+
+      // ロックタイマーをリセットし押し出し後の操作を許可
+      if (lockTimeout) {
+        clearTimeout(lockTimeout);
+        lockTimeout = undefined;
+      }
+      isLockActive = false;
+      lockMovesLeft = 15;
+
       updateGhostPosition();
     }
   };

--- a/src/models/tetromino.ts
+++ b/src/models/tetromino.ts
@@ -248,6 +248,21 @@ export function rotateTetrominoSRS(piece: Tetromino, dir: 1 | -1): SRSResult[] {
   }));
 }
 
+export function rotateTetrominoSRS180(piece: Tetromino): SRSResult[] {
+  const first = rotateTetrominoSRS(piece, 1);
+  const results: SRSResult[] = [];
+  for (const r1 of first) {
+    const second = rotateTetrominoSRS(r1.piece, 1);
+    for (const r2 of second) {
+      results.push({
+        piece: r2.piece,
+        offset: { row: r1.offset.row + r2.offset.row, col: r1.offset.col + r2.offset.col },
+      });
+    }
+  }
+  return results;
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // 5. 7‑bag random generator (unchanged interface)
 // ────────────────────────────────────────────────────────────────────────────

--- a/src/utils/keyBindings.ts
+++ b/src/utils/keyBindings.ts
@@ -1,0 +1,38 @@
+export interface KeyBindings {
+  moveLeft: string;
+  moveRight: string;
+  rotate: string;
+  rotate180: string;
+  softDrop: string;
+  hardDrop: string;
+  hold: string;
+  pause: string;
+  reset: string;
+}
+
+export const defaultKeyBindings: KeyBindings = {
+  moveLeft: 'a',
+  moveRight: 'd',
+  rotate: 'w',
+  rotate180: 'x',
+  softDrop: 's',
+  hardDrop: ' ',
+  hold: 'c',
+  pause: 'p',
+  reset: 'r',
+};
+
+export function loadKeyBindings(): KeyBindings {
+  try {
+    const stored = localStorage.getItem('keyBindings');
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      return { ...defaultKeyBindings, ...parsed };
+    }
+  } catch {}
+  return { ...defaultKeyBindings };
+}
+
+export function saveKeyBindings(bindings: KeyBindings) {
+  localStorage.setItem('keyBindings', JSON.stringify(bindings));
+}


### PR DESCRIPTION
## Summary
- enable configurable keys via new `KeySettingsModal`
- support 180 degree rotation with SRS in Tetris
- add basic Puyo Puyo gameplay mode with its own board and hook
- extend the main menu to select Puyo Puyo mode

## Testing
- `npm run build` *(fails: Cannot find module 'solid-js')*

------
https://chatgpt.com/codex/tasks/task_e_684034f7ef848328b02747e3902e5749