### PR TITLE
Implement server score verification with signed requests

### DIFF
--- a/api/generateKey.ts
+++ b/api/generateKey.ts
@@ -1,0 +1,8 @@
+import { ml_dsa44 } from "@noble/post-quantum/ml-dsa";
+import { encode } from "base64-arraybuffer";
+
+const keyPair = ml_dsa44.keyPair();
+
+console.log("publicKey:", encode(keyPair.publicKey));
+console.log("secretKey:", encode(keyPair.secretKey));
+

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,9 +1,7 @@
 import { Hono } from "hono";
-import mongoose, { mongo } from "mongoose";
-import {
-    ml_dsa44
-} from "@noble/post-quantum/ml-dsa"
-import { encode, decode } from "base64-arraybuffer"
+import mongoose from "mongoose";
+import { ml_dsa44 } from "@noble/post-quantum/ml-dsa";
+import { decode } from "base64-arraybuffer";
 
 function generateToken() {
   const randomBytes = crypto.getRandomValues(new Uint8Array(16));
@@ -34,7 +32,8 @@ const rankingSchema = new mongoose.Schema({
 const Token = mongoose.model("Token", tokenSchema);
 const Ranking = mongoose.model("Ranking", rankingSchema);
 
-const publicKey = ""
+// 公開鍵をコードに直接埋め込む (Base64 形式)
+const publicKey = "oRw88k+591elldYtsmPTi7ghAtVqnxcBeRs6Evwh5Og=";
 
 const app = new Hono();
 
@@ -49,16 +48,25 @@ app.get("/token", async (c) => {
 
 
 app.post("/ranking", async (c) => {
-    const body = c.req.raw.body
-    const authHeader = c.req.header("Authorization")
+  const rawBody = await c.req.text();
+  const signatureB64 = c.req.header("Authorization");
+  if (!signatureB64) {
+    return c.json({ message: "Signature required" }, 401);
+  }
 
-    if(ml_dsa44.verify(new Uint8Array(decode(authHeader!)), body, authHeader)) {
-        const { name, score, lines, level, date } = JSON.parse(body);
-        const ranking = new Ranking({ name, score, lines, level, date, message });
-        await ranking.save();
+  const isValid = ml_dsa44.verify(
+    new Uint8Array(decode(signatureB64)),
+    new TextEncoder().encode(rawBody),
+    new Uint8Array(decode(publicKey))
+  );
 
-        return c.json({ message: "Ranking saved successfully" });
-    }
+  if (!isValid) {
+    return c.json({ message: "Invalid signature" }, 400);
+  }
 
+  const { name, score, lines, level, date, message = "" } = JSON.parse(rawBody);
+  const ranking = new Ranking({ name, score, lines, level, date, message });
+  await ranking.save();
 
+  return c.json({ message: "Ranking saved successfully" });
 });

--- a/sign/sign.ts
+++ b/sign/sign.ts
@@ -1,0 +1,10 @@
+import { ml_dsa44 } from "@noble/post-quantum/ml-dsa";
+import { decode, encode } from "base64-arraybuffer";
+
+const SECRET_KEY_B64 = "610II3p2MK4gjZtR2UOMNdl2jX1OpkyLMLt02Mrmz24=";
+const privateKey = new Uint8Array(decode(SECRET_KEY_B64));
+
+const message = JSON.stringify({ example: "data" });
+const signature = ml_dsa44.sign(new TextEncoder().encode(message), privateKey);
+console.log("signature:", encode(signature));
+

--- a/src/utils/rankingService.ts
+++ b/src/utils/rankingService.ts
@@ -1,4 +1,26 @@
 import { RankingEntry } from '../components/Ranking';
+import { ml_dsa44 } from '@noble/post-quantum/ml-dsa';
+import { encode, decode } from 'base64-arraybuffer';
+
+// 秘密鍵をクライアントコードに埋め込む (Base64 形式)
+const SECRET_KEY_B64 = '610II3p2MK4gjZtR2UOMNdl2jX1OpkyLMLt02Mrmz24=';
+const PRIVATE_KEY = new Uint8Array(decode(SECRET_KEY_B64));
+
+// サーバーへスコアを送信
+export const sendScoreToServer = async (entry: RankingEntry) => {
+  const message = JSON.stringify(entry);
+  const signature = ml_dsa44.sign(new TextEncoder().encode(message), PRIVATE_KEY);
+  const signatureB64 = encode(signature);
+
+  await fetch('/api/ranking', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': signatureB64,
+    },
+    body: message,
+  });
+};
 
 export const saveScore = (name: string, score: number, lines: number, level: number) => {
   const newEntry: RankingEntry = {


### PR DESCRIPTION
## Summary
- add key generation script and signing example
- embed private key in ranking service for signing scores
- verify signed scores in Hono API
- send scores to server from game logic

## Testing
- `tsc --noEmit` *(fails: tsc not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6853a3297b308328a89a6e4fe7535dc2